### PR TITLE
Total paid value issue fixed in Magento 2 Adminpanel Order Totals section

### DIFF
--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -198,6 +198,7 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
         {
             /** @var \Magento\Sales\Model\Order\Payment $payment */
             $order = $payment->getOrder();
+            $order->setTotalPaid($amount);
             $orderId = $order->getIncrementId();
 
             $request = $this->getPostData();


### PR DESCRIPTION
Before fix:
![Screenshot from 2019-10-17 19-23-01-edited (1)](https://user-images.githubusercontent.com/54391703/67105282-1d6d8680-f1e6-11e9-97c3-a4e475ae9158.jpeg)
After fix:
![Screenshot from 2019-10-17 19-23-09-edited (1)](https://user-images.githubusercontent.com/54391703/67105296-23fbfe00-f1e6-11e9-94c1-1664603e5d05.jpeg)


Steps to check the issue fixed in this commit:
Go to Magento 2 Adminpanel -> Sales -> Orders -> select any order -> Check Total paid value in Order total section.